### PR TITLE
Fix: remove sensitive warning from config logging

### DIFF
--- a/sap_hana_config.js
+++ b/sap_hana_config.js
@@ -1,20 +1,21 @@
 module.exports = function(RED) {
-    
-	"use strict";
-	
-	function configNode(n) {
-        
-		//console.dir(n);
-		
-		RED.nodes.createNode(this, n);
-        
-		this.warn("Config reg : " + JSON.stringify(n));
-		
-		this.host = n.host;
+    "use strict";
+
+    function configNode(n) {
+        // Register the node with Node-RED
+        RED.nodes.createNode(this, n);
+
+        // ⚠️ Removed insecure logging of credentials
+        // If needed, you can enable debugging below without exposing sensitive data:
+        // this.debug("Initializing SAP HANA config with host=" + n.host + ", port=" + n.port);
+
+        // Assign configuration parameters to the node
+        this.host = n.host;
         this.port = parseInt(n.port);
         this.user = n.user;
-		this.password = n.password;
+        this.password = n.password;
     }
-	
+
+    // Register the node type
     RED.nodes.registerType("sap_hana_config", configNode);
 }


### PR DESCRIPTION
This pull request removes a this.warn() call that logs the entire config object, including sensitive credentials, to the Node-RED console. This poses a potential security risk, especially in shared or production environments. The line has been removed and a safe alternative using this.debug() is suggested in a comment.